### PR TITLE
Adds _zindex.scss

### DIFF
--- a/src/styles/base/_zindex.scss
+++ b/src/styles/base/_zindex.scss
@@ -1,0 +1,15 @@
+/// Document z-index values
+///
+/// Separates the document into three layers: bottom, overlay, middle, and top.
+///
+/// Bottom  - For the document and document level elements.
+/// Overlay - For modal overlays.
+/// Middle  - For modals.
+/// Top     - For elements which float above the document and modals such as drop down menus and popper.
+///
+/// Styleguide 1
+
+$dp-zindex-bottom: 0;
+$dp-zindex-overlay: 1;
+$dp-zindex-middle: 2;
+$dp-zindex-top: 3;

--- a/src/styles/components/_modal.scss
+++ b/src/styles/components/_modal.scss
@@ -5,6 +5,7 @@
   bottom: 0;
   left: 0;
   right: 0;
+  z-index: $dp-zindex-overlay;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -13,6 +14,7 @@
   background-color: $dp-greyscale-00;
   border: 1px solid $dp-sonic-secondary;
   border-radius: $rad-size-m;
+  z-index: $dp-zindex-middle;
   box-shadow: 0 3px 10px $dp-greyscale-850;
   max-width: 720px;
   min-width: 300px;

--- a/src/styles/components/_search.scss
+++ b/src/styles/components/_search.scss
@@ -24,7 +24,7 @@
   padding-top: 12px;
   padding-bottom: 12px;
   position: absolute;
-  z-index: 1;
+  z-index: $dp-zindex-top;
   background-color: #FFF;
   border-width: 1px;
   border-style: solid;
@@ -58,7 +58,7 @@
   }
 
   .dp-popper {
-    z-index: 1;
+    z-index: $dp-zindex-top;
 
     & > .dp-list {
       margin: 0;

--- a/src/styles/components/_select.scss
+++ b/src/styles/components/_select.scss
@@ -96,7 +96,7 @@ $select-input-border-color: $dp-greyscale-300;
   .dropdown-menu {
     top: 100%;
     left: 0;
-    z-index: 1000;
+    z-index: $dp-zindex-top;
     display: none;
     min-width: 160px;
     font-size: 14px;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -4,6 +4,7 @@ $fa-font-path: "//netdna.bootstrapcdn.com/font-awesome/4.7.0/fonts" !default;
 @import "base/colours";
 @import "base/fonts";
 @import "base/border-radius";
+@import "base/zindex";
 @import "base/mixins";
 @import "components/icons";
 @import "components/heading";

--- a/tests/storybook/components/modal.jsx
+++ b/tests/storybook/components/modal.jsx
@@ -25,6 +25,6 @@ storiesOf('Modal', module)
       >
         Test
       </Modal>
-    ),
+    )
   )
 ;


### PR DESCRIPTION
I have to add z-index to some of the components I'm working on, so I created some z-index related sass variables to help avoid z-index hell. The idea being to place all elements on one of three pre-defined page layers (plus overlay) instead of making up z-index values on the fly, e.g. 1001, 1002, 1003, and so on.

```scss
/// Document z-index values
///
/// Separates the document into three layers: bottom, overlay, middle, and top.
///
/// Bottom  - For the document and document level elements.
/// Overlay - For modal overlays.
/// Middle  - For modals.
/// Top     - For elements which float above the document and modals such as drop down menus and popper.
///
/// Styleguide 1

$dp-zindex-bottom: 0;
$dp-zindex-overlay: 1;
$dp-zindex-middle: 2;
$dp-zindex-top: 3;
```