### PR TITLE
Adds Input iconRight prop

### DIFF
--- a/src/Components/Forms/Input.jsx
+++ b/src/Components/Forms/Input.jsx
@@ -15,6 +15,7 @@ class Input extends React.Component {
     label:      PropTypes.string,
     id:         PropTypes.string,
     icon:       PropTypes.string,
+    iconRight:  PropTypes.string,
     prefix:     PropTypes.string,
     suffix:     PropTypes.string,
     validated:  PropTypes.bool,
@@ -66,11 +67,11 @@ class Input extends React.Component {
   };
 
   getIcon = () => {
-    const { icon } = this.props;
-    if (!icon) {
+    const { icon, iconRight } = this.props;
+    if (!icon && !iconRight) {
       return null;
     }
-    return <Icon name={icon} />;
+    return <Icon name={icon || iconRight} />;
   };
 
   getPrefix = () => {
@@ -94,7 +95,7 @@ class Input extends React.Component {
   };
 
   render() {
-    const { className, validated, validating, icon, prefix, suffix, ...props } = this.props;
+    const { className, validated, validating, icon, iconRight, prefix, suffix, ...props } = this.props;
     return (
       <div
         className={
@@ -102,12 +103,13 @@ class Input extends React.Component {
             'dp-input',
             className,
             {
-              'dp-input--validating':  validating,
-              'dp-input--validated':   validated,
-              'dp-input--with-icon':   icon,
-              'dp-input--with-prefix': prefix,
-              'dp-input--with-suffix': suffix,
-              'dp-input--focused':     this.state.focus,
+              'dp-input--validating':       validating,
+              'dp-input--validated':        validated,
+              'dp-input--with-icon':        icon && !iconRight,
+              'dp-input--with-icon--right': !icon && iconRight,
+              'dp-input--with-prefix':      prefix,
+              'dp-input--with-suffix':      suffix,
+              'dp-input--focused':          this.state.focus,
             }
           )
         }

--- a/src/styles/components/_input.scss
+++ b/src/styles/components/_input.scss
@@ -3,6 +3,7 @@
 *******************************/
 .dp-input {
   position: relative;
+  display: inline-block;
   flex: 1 0 auto;
   &, * {
     box-sizing: border-box;
@@ -150,14 +151,27 @@
   input {
     padding-left: 24px;
   }
+  .dp-icon {
+    position: absolute;
+    left: 6px;
+    color: $dp-greyscale-400;
+    font-size: $icon-size-s;
+    top: calc(50% - #{$icon-size-s / 2});
+  }
 }
-.dp-input .dp-icon {
-  position: absolute;
-  left: 6px;
-  color: $dp-greyscale-400;
-  font-size: $icon-size-s;
-  top: calc(50% - #{$icon-size-s / 2});
+.dp-input--with-icon--right {
+  input {
+    padding-right: 24px;
+  }
+  .dp-icon {
+    position: absolute;
+    right: 6px;
+    color: $dp-greyscale-400;
+    font-size: $icon-size-s;
+    top: calc(50% - #{$icon-size-s / 2});
+  }
 }
+
 /******************************
     Input prefix / suffix
 *******************************/

--- a/tests/storybook/components/forms/input.jsx
+++ b/tests/storybook/components/forms/input.jsx
@@ -70,11 +70,17 @@ storiesOf('Forms', module)
           validated
         /><br />
         <h3>Icons</h3>
-        <Label>With icon</Label>
+        <Label>With icon left</Label>
         <Input
           disabled={boolean('Disabled', false)}
           readOnly={boolean('Readonly', false)}
           icon="search"
+        /><br />
+        <Label>With icon right</Label>
+        <Input
+          disabled={boolean('Disabled', false)}
+          readOnly={boolean('Readonly', false)}
+          iconRight="calendar"
         /><br />
         <h3>Prefix / Suffix</h3>
         <Label>Prefix</Label>


### PR DESCRIPTION
Adds the ability to display an icon inside of an `Input` component on the right side. Will be needed to display the calendar icon in the date picker.

Also changes `.dp-input` to be an inline-block element. (All form elements should be.)