### PR TITLE
Adds onchange name

### DIFF
--- a/docs/components/forms/group.md
+++ b/docs/components/forms/group.md
@@ -16,7 +16,7 @@ Groups a label and form children together.
 Value for the group label.
 
 **htmlFor={string}**  
-ID of the child the label belongs to.
+ID of the child the label belongs to. When ommitted the component will try to discover the ID of the child input element.
 
 
 ### CSS

--- a/docs/components/tabs/tabs.md
+++ b/docs/components/tabs/tabs.md
@@ -35,7 +35,7 @@ Adds `dp-tabs` to the root element.
 ```jsx
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Pane from 'Components/Pane';
+import Section from 'Components/Section';
 import { Tabs, TabLink } from 'Components/Tabs';
 
 class App extends React.Component {
@@ -62,15 +62,15 @@ class App extends React.Component {
             Tab One
           </TabLink>
         </Tabs>
-        <Pane hidden={activePane !== 'one'}>
+        <Section hidden={activePane !== 'one'}>
           Tab one!
-        </Pane>
-        <Pane hidden={activePane !== 'two'}>
+        </Section>
+        <Section hidden={activePane !== 'two'}>
           Tab two!
-        </Pane>
-        <Pane hidden={activePane !== 'three'}>
+        </Section>
+        <Section hidden={activePane !== 'three'}>
           Tab three!
-        </Pane>
+        </Section>
       </div>
     );
   }

--- a/src/Components/Forms/Checkbox.jsx
+++ b/src/Components/Forms/Checkbox.jsx
@@ -60,7 +60,7 @@ class Checkbox extends React.Component {
       event.stopPropagation();
     }
     if (!this.props.disabled && !this.props.readOnly) {
-      this.props.onChange(event.target.checked, this.props.value);
+      this.props.onChange(event.target.checked, this.props.value, event.target.name);
     }
   };
 

--- a/src/Components/Forms/Group.jsx
+++ b/src/Components/Forms/Group.jsx
@@ -1,44 +1,59 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { childrenRecursiveMap } from 'utils/props';
+import { objectKeyFilter } from 'utils/objects';
 import Label from 'Components/Forms/Label';
 
-/**
- * Groups a label and form children together.
- */
-const Group = ({ label, htmlFor, className, children, ...props }) => (
-  <div className={classNames('dp-form-group', className)} {...props}>
-    {label && <Label htmlFor={htmlFor}>
-      {label}
-    </Label>}
-    {children}
-  </div>
-);
+class Group extends React.Component {
+  static propTypes = {
+    /**
+     * Value for the group label.
+     */
+    label:     PropTypes.string,
+    /**
+     * ID of the child the label belongs to.
+     */
+    htmlFor:   PropTypes.string,
+    /**
+     * CSS classes to apply to the element.
+     */
+    className: PropTypes.string,
+    /**
+     * Children to render.
+     */
+    children:  PropTypes.node
+  };
 
-Group.propTypes = {
-  /**
-   * Value for the group label.
-   */
-  label:     PropTypes.string,
-  /**
-   * ID of the child the label belongs to.
-   */
-  htmlFor:   PropTypes.string,
-  /**
-   * CSS classes to apply to the element.
-   */
-  className: PropTypes.string,
-  /**
-   * Children to render.
-   */
-  children:  PropTypes.node
-};
+  static defaultProps = {
+    label:     '',
+    htmlFor:   '',
+    className: '',
+    children:  ''
+  };
 
-Group.defaultProps = {
-  label:     '',
-  htmlFor:   '',
-  className: '',
-  children:  ''
-};
+  render() {
+    const { label, className, children, ...props } = this.props;
+    let { htmlFor } = this.props;
+
+    if (htmlFor === '') {
+      childrenRecursiveMap(children, (child) => {
+        if (child.props.id !== undefined && htmlFor === '') {
+          htmlFor = child.props.id;
+        }
+      });
+    }
+
+    return (
+      <div
+        className={classNames('dp-form-group', className)}
+        {...objectKeyFilter(props, Group.propTypes)}
+      >
+        {label && <Label htmlFor={htmlFor}>{label}</Label>}
+        {children}
+      </div>
+    );
+  }
+}
 
 export default Group;

--- a/src/Components/Forms/Input.jsx
+++ b/src/Components/Forms/Input.jsx
@@ -64,7 +64,7 @@ class Input extends React.Component {
   }
 
   onChange = (event) => {
-    this.props.onChange(event.currentTarget.value || '');
+    this.props.onChange(event.currentTarget.value || '', event.currentTarget.name || '');
   };
 
   onFocus = (e) => {

--- a/src/Components/Forms/Radio.jsx
+++ b/src/Components/Forms/Radio.jsx
@@ -43,7 +43,7 @@ class Radio extends React.Component {
     if (this.props.stopPropagation) {
       event.stopPropagation();
     }
-    this.props.onChange(event.target.checked, this.props.value);
+    this.props.onChange(event.target.checked, this.props.value, event.target.name);
   };
 
   render() {

--- a/src/Components/Forms/SearchButton.jsx
+++ b/src/Components/Forms/SearchButton.jsx
@@ -95,10 +95,10 @@ export default class SearchButton extends Input {
     this.setState({ opened: !this.state.opened });
   };
 
-  handleChange = (value) => {
+  handleChange = (value, name) => {
     this.resultsRef.setIndex(-1);
     this.setState({ value }, () => {
-      this.props.onChange(value);
+      this.props.onChange(value, name);
     });
   };
 

--- a/src/Components/Forms/Select.jsx
+++ b/src/Components/Forms/Select.jsx
@@ -11,6 +11,10 @@ class Select extends React.Component {
      */
     className:   PropTypes.string,
     /**
+     * Name of the form element.
+     */
+    name:        PropTypes.string,
+    /**
      * Displayed in the drop down before a value is entered.
      */
     placeholder: PropTypes.string,
@@ -35,9 +39,11 @@ class Select extends React.Component {
       })
     ).isRequired,
   };
+
   static defaultProps = {
     placeholder: 'Please select',
     multiple:    false,
+    name:        '',
     icon:        '',
     className:   '',
     onChange() {},
@@ -52,11 +58,11 @@ class Select extends React.Component {
   };
 
   handleChange = (value) => {
-    this.props.onChange(value);
+    this.props.onChange(value, this.props.name);
   };
 
   render() {
-    const { icon, className, ...elementProps } = this.props;
+    const { icon, name, className, ...elementProps } = this.props;
     const props = Object.assign({}, elementProps);
     delete props.onChange;
     return (
@@ -73,6 +79,7 @@ class Select extends React.Component {
       >
         {this.getIcon()}
         <ReactSelect
+          name={name}
           className={classNames('dp-select', className)}
           onChange={this.handleChange}
           {...props}

--- a/src/styles/components/_input.scss
+++ b/src/styles/components/_input.scss
@@ -454,11 +454,42 @@
 }
 
 /******************************
+    Form Group
+*******************************/
+.dp-form-group {
+  display: block;
+  width: 100%;
+  margin-bottom: 10px;
+
+  .dp-input,
+  .dp-input input,
+  .dp-select,
+  .dp-textarea {
+    display: block;
+    width: 100%;
+  }
+}
+
+/******************************
     Textarea
 *******************************/
 .dp-textarea {
+  position: relative;
+  display: inline-block;
+  flex: 1 0 auto;
+  &, * {
+    box-sizing: border-box;
+  }
+
   textarea {
     width: 100%;
     height: 100%;
+    font-family: $primary-font;
+    font-weight: $pf-regular;
+    color: $dp-greyscale-850;
+    font-size: $font-size-m;
+    border-radius: $rad-size-m;
+    padding-left: 8px;
+    border: 1px solid $dp-greyscale-300;
   }
 }

--- a/src/styles/components/_select.scss
+++ b/src/styles/components/_select.scss
@@ -20,7 +20,6 @@ $select-input-border-color: $dp-greyscale-300;
   font-weight: $pf-regular;
 
   height: 24px;
-  margin-bottom: 10px;
   font-size: $font-size-m;
 
   .Select-control {

--- a/tests/storybook/components/forms/group.jsx
+++ b/tests/storybook/components/forms/group.jsx
@@ -5,11 +5,10 @@ import { Group, Input } from 'Components/Forms';
 storiesOf('Forms', module)
   .add('Group', () => (
     <div style={{ margin: 10 }}>
-      <Group label="Username" htmlFor="test-username">
+      <Group label="Username">
         <Input id="test-username" />
       </Group>
     </div>
   )
 )
 ;
-

--- a/tests/storybook/components/forms/input.jsx
+++ b/tests/storybook/components/forms/input.jsx
@@ -14,18 +14,21 @@ storiesOf('Forms', module)
         <h3>Sizes</h3>
         <Label>Small</Label>
         <Input
+          name="input-1"
           className="dp-input--small"
           disabled={boolean('Disabled', false)}
           readOnly={boolean('Readonly', false)}
         /><br />
         <Label>Medium</Label>
         <Input
+          name="input-2"
           className="dp-input--medium"
           disabled={boolean('Disabled', false)}
           readOnly={boolean('Readonly', false)}
         /><br />
         <Label>Large</Label>
         <Input
+          name="input-3"
           className="dp-input--large"
           disabled={boolean('Disabled', false)}
           readOnly={boolean('Readonly', false)}
@@ -33,18 +36,21 @@ storiesOf('Forms', module)
         <h3>Fonts</h3>
         <Label>Email Address</Label>
         <Input
+          name="input-4"
           value="hello@test.com"
           disabled={boolean('Disabled', false)}
           readOnly={boolean('Readonly', false)}
         /><br />
         <Label>Placeholder</Label>
         <Input
+          name="input-5"
           placeholder="e.g. hello@test.com"
           disabled={boolean('Disabled', false)}
           readOnly={boolean('Readonly', false)}
         /><br />
         <Label>Error display</Label>
         <Input
+          name="input-5"
           className="dp-input--error"
           disabled={boolean('Disabled', false)}
           readOnly={boolean('Readonly', false)}
@@ -52,6 +58,7 @@ storiesOf('Forms', module)
         <Label>Error display</Label>
         <Input
           required
+          name="input-6"
           className="dp-input--error"
           disabled={boolean('Disabled', false)}
           readOnly={boolean('Readonly', false)}
@@ -59,12 +66,14 @@ storiesOf('Forms', module)
         <h3>Validation</h3>
         <Label>Validating</Label>
         <Input
+          name="input-7"
           disabled={boolean('Disabled', false)}
           readOnly={boolean('Readonly', false)}
           validating
         /><br />
         <Label>Validated</Label>
         <Input
+          name="input-8"
           disabled={boolean('Disabled', false)}
           readOnly={boolean('Readonly', false)}
           validated
@@ -72,12 +81,14 @@ storiesOf('Forms', module)
         <h3>Icons</h3>
         <Label>With icon left</Label>
         <Input
+          name="input-10"
           disabled={boolean('Disabled', false)}
           readOnly={boolean('Readonly', false)}
           icon="search"
         /><br />
         <Label>With icon right</Label>
         <Input
+          name="input-11"
           disabled={boolean('Disabled', false)}
           readOnly={boolean('Readonly', false)}
           iconRight="calendar"
@@ -85,6 +96,7 @@ storiesOf('Forms', module)
         <h3>Visibility</h3>
         <Label>Invisible border</Label>
         <Input
+          name="input-12"
           value="Support Team"
           disabled={boolean('Disabled', false)}
           readOnly={boolean('Readonly', false)}
@@ -93,6 +105,7 @@ storiesOf('Forms', module)
         /><br /><br />
         <Label>With placeholder</Label>
         <Input
+          name="input-13"
           placeholder="Add note"
           disabled={boolean('Disabled', false)}
           readOnly={boolean('Readonly', false)}
@@ -101,6 +114,7 @@ storiesOf('Forms', module)
         <h3>Prefix / Suffix</h3>
         <Label>Prefix</Label>
         <Input
+          name="input-14"
           disabled={boolean('Disabled', false)}
           readOnly={boolean('Readonly', false)}
           className={classNames({ 'dp-input--error': boolean('Error', false) })}
@@ -108,6 +122,7 @@ storiesOf('Forms', module)
         /><br />
         <Label>Suffix</Label>
         <Input
+          name="input-15"
           disabled={boolean('Disabled', false)}
           readOnly={boolean('Readonly', false)}
           className={classNames({ 'dp-input--error': boolean('Error', false) })}
@@ -115,6 +130,7 @@ storiesOf('Forms', module)
         /><br />
         <Label>Both</Label>
         <Input
+          name="input-16"
           disabled={boolean('Disabled', false)}
           readOnly={boolean('Readonly', false)}
           className={classNames({ 'dp-input--error': boolean('Error', false) })}

--- a/tests/storybook/components/forms/select.jsx
+++ b/tests/storybook/components/forms/select.jsx
@@ -18,6 +18,7 @@ storiesOf('Forms', module)
         <h3>Selects</h3>
         <Label>Basic</Label>
         <Select
+          name="select-1"
           onChange={action('Select change')}
           options={basicOptions}
           disabled={boolean('Disabled', false)}
@@ -25,6 +26,7 @@ storiesOf('Forms', module)
         <Label>Basic with Icon</Label>
         <Select
           icon="search"
+          name="select-2"
           onChange={action('Select change')}
           options={basicOptions}
           disabled={boolean('Disabled', false)}


### PR DESCRIPTION
The input/select onChange handlers only pass the value to the listeners, but sometimes the listeners need the name of the input as well, which allows this common pattern to be used:

```js
constructor(props) {
  super(props);
  this.state = {
    values: {}
  };
}

handleChange = (value, name) => {
  const values = Object.assign({}, this.state.values);
  values[name] = value;
  this.setState({ values });
};

render() {
  const { values } = this.state;

  return (
    <div>
      <Input
        name="username"
        value={values.username}
        onChange={this.handleChange}
      />
      <Input
        name="email"
        value={values.email}
        onChange={this.handleChange}
      />
    </div>
  );
}
```