### PR TITLE
Fix initial state of datepicker

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8717,8 +8717,7 @@
     "moment": {
       "version": "2.18.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
-      "dev": true
+      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "bourbon-neat": "^2.1.0",
     "classnames": "^2.2.5",
     "font-awesome": "^4.7.0",
+    "moment": "^2.18.1",
     "popper.js": "^1.12.5",
     "prop-types": "^15.5.10",
     "react": "^15.6.1",

--- a/src/Components/Forms/Datepicker.jsx
+++ b/src/Components/Forms/Datepicker.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import noop from 'utils/noop';
@@ -20,6 +21,14 @@ export default class Datepicker extends React.Component {
      * Text to display in the input field until a value is chosen.
      */
     placeholder: PropTypes.string,
+    /**
+     * Moment format to use to render the input when the date is selected.
+     */
+    format:      PropTypes.string,
+    /**
+     * Initial value of the input (this property has priority over the date one)
+     */
+    value:       PropTypes.string,
     /**
      * The initial date to display.
      */
@@ -56,7 +65,9 @@ export default class Datepicker extends React.Component {
 
   static defaultProps = {
     placeholder: 'DD/MM/YYYY',
-    date:        new Date(),
+    format:      'DD/MM/YYYY',
+    value:       '',
+    date:        null,
     days:        DAYS,
     months:      MONTHS,
     onSelect:    noop,
@@ -69,9 +80,19 @@ export default class Datepicker extends React.Component {
   constructor(props) {
     super(props);
 
+    let date = props.date;
+
+    if (props.value) {
+      date = moment(props.value, props.format).toDate();
+    }
+
+    if (!date) {
+      date = new Date();
+    }
+
     this.state = {
-      date:   props.date,
-      value:  null,
+      date,
+      value:  props.value ? date : null,
       opened: false
     };
 
@@ -98,6 +119,9 @@ export default class Datepicker extends React.Component {
 
   componentDidMount() {
     this.inputDOM   = this.inputRef.input;
+    if (this.props.date) {
+      this.inputRef.setValue(moment(this.props.date).format(this.props.format));
+    }
     this.popperDOM = ReactDOM.findDOMNode(this.popperRef);
     this.updatePopperWidth();
 
@@ -186,7 +210,7 @@ export default class Datepicker extends React.Component {
    * @param {Date} date
    */
   handleDayClick(date) {
-    this.inputRef.setValue(`${date.getDate()}/${date.getMonth() + 1}/${date.getFullYear()}`);
+    this.inputRef.setValue(moment(date).format(this.props.format));
     this.popperRef.close();
     this.props.onSelect(date);
     this.setState({ value: date });
@@ -196,10 +220,14 @@ export default class Datepicker extends React.Component {
    * Called when the input value changes
    */
   handleInputChange(e) {
-    const value = new Date(this.inputRef.getValue());
-    if (value) {
-      this.props.onSelect(value);
-      this.setState({ value });
+    const value = moment(this.inputRef.getValue(), this.props.format);
+    if (value.isValid()) {
+      const date = value.toDate();
+      this.props.onSelect(date);
+      this.setState({
+        value: date,
+        date
+      });
     }
     if (this.props.onChange) {
       this.props.onChange(e);
@@ -295,7 +323,7 @@ export default class Datepicker extends React.Component {
 
   render() {
     const { opened } = this.state;
-    const { style, placeholder, className, ...props } = this.props;
+    const { style, placeholder, className, value, ...props } = this.props;
     const inputProps = objectKeyFilter(props, Datepicker.propTypes);
 
     return (
@@ -316,6 +344,7 @@ export default class Datepicker extends React.Component {
           placeholder={placeholder}
           onFocus={this.handleInputFocus}
           onChange={this.handleInputChange}
+          value={value}
           {...inputProps}
         />
         <Popper

--- a/tests/storybook/components/forms/datepicker.jsx
+++ b/tests/storybook/components/forms/datepicker.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
+import { storiesOf, action } from '@storybook/react';
 import { Datepicker } from 'Components/Forms';
 
 storiesOf('Forms', module)
   .add(
   'Datepicker',
-  () => <Datepicker />
+  () => (
+    <div>
+      <Datepicker onChange={action('onChange')} onSelect={action('onSelect')} />
+      <Datepicker onChange={action('onChange')} onSelect={action('onSelect')} value="01/01/2018" />
+    </div>
+  )
 )
 ;


### PR DESCRIPTION
The calendar was not initialising itself if a value was provided and the date from the input could be matched in American format, so I added a couple of things by using moment.
I guess it should be adding a bit of weight to the package but that shouldn't be so bad.